### PR TITLE
NP-2402 uninstall and decommission cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ To provision a new cluster:
 provisioner-cli provision [flags]
 ```
 
+To decommission an existing cluster:
+```shell script
+provisioner-cli decommission --azureCredentialsPath {{path-to-azure-credentials}} --name {{cluster-name}} --platform AZURE --resourceGroup {{resource-group}}
+```
+
 ## Contributing
 
 Please read [contributing.md](contributing.md) for details on our code of conduct, and the process for submitting pull requests to us.

--- a/cmd/provisioner-cli/commands/decommission.go
+++ b/cmd/provisioner-cli/commands/decommission.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Nalej
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package commands
+
+import (
+	"fmt"
+	"github.com/nalej/grpc-infrastructure-go"
+	"github.com/nalej/grpc-installer-go"
+	"github.com/nalej/grpc-provisioner-go"
+	"github.com/nalej/provisioner/internal/app/provisioner-cli"
+	"github.com/rs/zerolog/log"
+	uuid "github.com/satori/go.uuid"
+	"github.com/spf13/cobra"
+)
+
+// DecommissionRequest contains the elements that will be requested to perform a decommission operation.
+var decommissionRequest grpc_provisioner_go.DecomissionClusterRequest
+
+// provisionCmd with the command to provision a new cluster.
+var decommissionCmd = &cobra.Command{
+	Use:   "decommission",
+	Short: "Decommission a cluster",
+	Long:  `Decommission an existing cluster using a specific infrastructure provider`,
+	Run: func(cmd *cobra.Command, args []string) {
+		SetupLogging()
+		ConfigureDecommission()
+		TriggerDecommission()
+	},
+}
+
+// ConfigureProvisioning configures the options using the standard gRPC structures for the provisioning command.
+func ConfigureDecommission() {
+	decommissionRequest.RequestId = fmt.Sprintf("cli-decommission-%s", uuid.NewV4().String())
+	decommissionRequest.OrganizationId = "nalej"
+	// From the CLI only management clusters may be decommissioned.
+	decommissionRequest.IsManagementCluster = true
+	// Only kubernetes clusters for now
+	decommissionRequest.ClusterType = grpc_infrastructure_go.ClusterType_KUBERNETES
+	// Determine target platform
+	targetPlatform, err := GetTargetPlatform(targetPlatform)
+	ExitOnError(err, "cannot determine target platform")
+	decommissionRequest.TargetPlatform = targetPlatform
+
+	// Load credentials depending on the target platform
+	if decommissionRequest.TargetPlatform == grpc_installer_go.Platform_AZURE {
+		if azureCredentialsPath == "" {
+			log.Fatal().Msg("azureCredentialsPath must be specified")
+		}
+		credentials, err := LoadAzureCredentials(azureCredentialsPath)
+		ExitOnError(err, "cannot load infrastructure provider credentials")
+		decommissionRequest.AzureCredentials = credentials
+		if azureOptions.ResourceGroup == "" {
+			log.Fatal().Msg("resourceGroup must be specified")
+		}
+		decommissionRequest.AzureOptions = &azureOptions
+	}
+	cfg.LaunchService = false
+}
+
+// TriggerDecommission triggers the creation of the CLI Decommissioner and proceeds to execute the operation.
+func TriggerDecommission() {
+	cliDecommissioner := provisioner_cli.NewCLIDecommissioner(&decommissionRequest, cfg)
+	err := cliDecommissioner.Run()
+	ExitOnError(err, "scaling failed")
+}
+
+func init() {
+	decommissionCmd.Flags().StringVar(&decommissionRequest.ClusterId, "name", "",
+		"Name of the cluster for management cluster requests")
+	decommissionCmd.Flags().StringVar(&targetPlatform, "platform", "",
+		"Target plaftorm determining the provider: AZURE or BAREMETAL")
+	decommissionCmd.Flags().StringVar(&azureCredentialsPath, "azureCredentialsPath", "",
+		"Path to the file containing the azure credentials")
+	decommissionCmd.Flags().StringVar(&azureOptions.ResourceGroup, "resourceGroup", "",
+		"Target resource group where the cluster will be created. Only for Azure platform.")
+
+	rootCmd.AddCommand(decommissionCmd)
+}

--- a/internal/app/provisioner-cli/clidecommissioner.go
+++ b/internal/app/provisioner-cli/clidecommissioner.go
@@ -81,7 +81,7 @@ func (cs *CLIDecommissioner) Run() derrors.Error {
 	fmt.Println("Decommissioning took ", elapsed)
 	// Process the result
 	result := operation.Result()
-	cs.printJSONResult("unknown", result)
+	cs.printJSONResult(cs.request.ClusterId, result)
 	// cp.printTableResult(result)
 	return nil
 }

--- a/internal/app/provisioner-cli/clidecommissioner.go
+++ b/internal/app/provisioner-cli/clidecommissioner.go
@@ -28,19 +28,19 @@ import (
 	"time"
 )
 
-// CLIScaler structure to watch the scaling process.
-type CLIScaler struct {
+// CLIDecommissioner structure to watch the decommission process.
+type CLIDecommissioner struct {
 	*CLICommon
-	request  *grpc_provisioner_go.ScaleClusterRequest
+	request  *grpc_provisioner_go.DecomissionClusterRequest
 	Executor workflow.Executor
 	config   *config.Config
 }
 
-// NewCLIScaler creates a new CLI managed scaler without a service.
-func NewCLIScaler(
-	request *grpc_provisioner_go.ScaleClusterRequest,
-	config *config.Config) *CLIScaler {
-	return &CLIScaler{
+// NewCLIDecommissioner creates a new CLI managed decommissioner without a service.
+func NewCLIDecommissioner(
+	request *grpc_provisioner_go.DecomissionClusterRequest,
+	config *config.Config) *CLIDecommissioner {
+	return &CLIDecommissioner{
 		CLICommon: &CLICommon{lastLogEntry: 0},
 		request:   request,
 		Executor:  workflow.GetExecutor(),
@@ -48,21 +48,21 @@ func NewCLIScaler(
 	}
 }
 
-func (cs *CLIScaler) Run() derrors.Error {
+func (cs *CLIDecommissioner) Run() derrors.Error {
 	vErr := cs.config.Validate()
 	if vErr != nil {
 		log.Fatal().Str("err", vErr.DebugReport()).Msg("invalid configuration")
 	}
 	cs.config.Print()
-	log.Debug().Str("target_platform", cs.request.TargetPlatform.String()).Msg("Scale request received")
+	log.Debug().Str("target_platform", cs.request.TargetPlatform.String()).Msg("Decommission request received")
 	infraProvider, err := provider.NewInfrastructureProvider(cs.request.TargetPlatform, cs.request.AzureCredentials, cs.config)
 	if err != nil {
 		log.Error().Msg("cannot obtain infrastructure provider")
 		return err
 	}
-	operation, err := infraProvider.Scale(entities.NewScaleRequest(cs.request))
+	operation, err := infraProvider.Decommission(entities.NewDecommissionRequest(cs.request))
 	if err != nil {
-		log.Error().Str("trace", err.DebugReport()).Msg("cannot create scale operation")
+		log.Error().Str("trace", err.DebugReport()).Msg("cannot create decommission operation")
 		return err
 	}
 
@@ -73,12 +73,12 @@ func (cs *CLIScaler) Run() derrors.Error {
 		time.Sleep(15 * time.Second)
 		cs.printOperationLog(operation.Log())
 		if checks%4 == 0 {
-			fmt.Printf("Scaling operation %s - %s\n", entities.TaskProgressToString[operation.Progress()], time.Since(start).String())
+			fmt.Printf("Provision operation %s - %s\n", entities.TaskProgressToString[operation.Progress()], time.Since(start).String())
 		}
 		checks++
 	}
 	elapsed := time.Since(start)
-	fmt.Println("Scaling took ", elapsed)
+	fmt.Println("Provisioning took ", elapsed)
 	// Process the result
 	result := operation.Result()
 	cs.printJSONResult("unknown", result)

--- a/internal/app/provisioner-cli/clidecommissioner.go
+++ b/internal/app/provisioner-cli/clidecommissioner.go
@@ -57,7 +57,7 @@ func (cs *CLIDecommissioner) Run() derrors.Error {
 	log.Debug().Str("target_platform", cs.request.TargetPlatform.String()).Msg("Decommission request received")
 	infraProvider, err := provider.NewInfrastructureProvider(cs.request.TargetPlatform, cs.request.AzureCredentials, cs.config)
 	if err != nil {
-		log.Error().Msg("cannot obtain infrastructure provider")
+		log.Error().Str("provider", cs.request.TargetPlatform.String()).Msg("cannot obtain infrastructure provider")
 		return err
 	}
 	operation, err := infraProvider.Decommission(entities.NewDecommissionRequest(cs.request))
@@ -73,12 +73,12 @@ func (cs *CLIDecommissioner) Run() derrors.Error {
 		time.Sleep(15 * time.Second)
 		cs.printOperationLog(operation.Log())
 		if checks%4 == 0 {
-			fmt.Printf("Provision operation %s - %s\n", entities.TaskProgressToString[operation.Progress()], time.Since(start).String())
+			fmt.Printf("Decommission operation %s - %s\n", entities.TaskProgressToString[operation.Progress()], time.Since(start).String())
 		}
 		checks++
 	}
 	elapsed := time.Since(start)
-	fmt.Println("Provisioning took ", elapsed)
+	fmt.Println("Decommissioning took ", elapsed)
 	// Process the result
 	result := operation.Result()
 	cs.printJSONResult("unknown", result)

--- a/internal/app/provisioner/decommissioner/handler.go
+++ b/internal/app/provisioner/decommissioner/handler.go
@@ -19,6 +19,9 @@ package decommissioner
 import (
 	"github.com/nalej/grpc-common-go"
 	"github.com/nalej/grpc-provisioner-go"
+	"github.com/nalej/grpc-utils/pkg/conversions"
+	"github.com/nalej/provisioner/internal/pkg/entities"
+	"github.com/rs/zerolog/log"
 	"golang.org/x/net/context"
 )
 
@@ -30,15 +33,20 @@ func NewHandler(manager Manager) *Handler {
 	return &Handler{manager}
 }
 
-func (h *Handler) DecomissionCluster(_ context.Context, request *grpc_provisioner_go.DecomissionClusterRequest) (*grpc_common_go.OpResponse, error) {
-	panic("implement me")
+func (h *Handler) DecomissionCluster(ctx context.Context, request *grpc_provisioner_go.DecomissionClusterRequest) (*grpc_common_go.OpResponse, error) {
+	err := entities.ValidDecommissionClusterRequest(request)
+	if err != nil {
+		log.Warn().Str("trace", err.DebugReport()).Msg(err.Error())
+		return nil, conversions.ToGRPCError(err)
+	}
+	log.Debug().Interface("request", request).Msg("decommission cluster")
+	return h.Manager.DecommissionCluster(request)
 }
 
 func (h *Handler) CheckProgress(_ context.Context, request *grpc_common_go.RequestId) (*grpc_common_go.OpResponse, error) {
-	panic("implement me")
+	return h.Manager.CheckProgress(request)
 }
 
 func (h *Handler) RemoveDecomission(_ context.Context, request *grpc_common_go.RequestId) (*grpc_common_go.Success, error) {
-	panic("implement me")
+	return h.Manager.RemoveDecommission(request)
 }
-

--- a/internal/app/provisioner/decommissioner/manager.go
+++ b/internal/app/provisioner/decommissioner/manager.go
@@ -20,15 +20,18 @@ import (
 	"github.com/nalej/derrors"
 	"github.com/nalej/grpc-common-go"
 	"github.com/nalej/grpc-provisioner-go"
+	"github.com/nalej/provisioner/internal/app/provisioner/provider"
 	"github.com/nalej/provisioner/internal/pkg/config"
 	"github.com/nalej/provisioner/internal/pkg/entities"
 	"github.com/nalej/provisioner/internal/pkg/workflow"
+	"github.com/rs/zerolog/log"
 	"sync"
+	"time"
 )
 
 type Manager struct {
 	sync.Mutex
-	Config config.Config
+	Config   config.Config
 	Executor workflow.Executor
 	// Operation per request identifier.
 	Operation map[string]entities.InfrastructureOperation
@@ -36,20 +39,61 @@ type Manager struct {
 
 func NewManager(config config.Config) Manager {
 	return Manager{
-		Config: config,
+		Config:    config,
 		Executor:  workflow.GetExecutor(),
 		Operation: make(map[string]entities.InfrastructureOperation, 0),
 	}
 }
 
 func (m *Manager) DecommissionCluster(request *grpc_provisioner_go.DecomissionClusterRequest) (*grpc_common_go.OpResponse, derrors.Error) {
-	panic("implement me")
+	infraProvider, err := provider.NewInfrastructureProvider(request.TargetPlatform, request.AzureCredentials, &m.Config)
+	if err != nil {
+		return nil, err
+	}
+	operation, err := infraProvider.Decommission(entities.NewDecommissionRequest(request))
+	if err != nil {
+		log.Error().Str("trace", err.DebugReport()).Msg("cannot create decommission operation")
+		return nil, err
+	}
+	m.Lock()
+	defer m.Unlock()
+
+	_, exists := m.Operation[request.RequestId]
+	if exists {
+		return nil, derrors.NewAlreadyExistsError("request is already being processed")
+	}
+	m.Operation[request.RequestId] = operation
+	// schedule the operation for execution
+	m.Executor.ScheduleOperation(operation)
+	// return initial response for the request
+	response := &grpc_common_go.OpResponse{
+		OrganizationId: request.GetOrganizationId(),
+		RequestId:      request.GetRequestId(),
+		OperationName:  entities.ToOperationTypeString[entities.Decommission],
+		Timestamp:      time.Now().Unix(),
+		Status:         grpc_common_go.OpStatus_SCHEDULED,
+	}
+	return response, nil
 }
 
 func (m *Manager) CheckProgress(request *grpc_common_go.RequestId) (*grpc_common_go.OpResponse, derrors.Error) {
-	panic("implement me")
+	m.Lock()
+	defer m.Unlock()
+	operation, exists := m.Operation[request.RequestId]
+	if !exists {
+		return nil, derrors.NewNotFoundError("request_id not found")
+	}
+	result := operation.Result()
+	return result.ToOpResponse()
 }
 
 func (m *Manager) RemoveDecommission(request *grpc_common_go.RequestId) (*grpc_common_go.Success, derrors.Error) {
-	panic("implement me")
+	m.Lock()
+	defer m.Unlock()
+	_, exists := m.Operation[request.GetRequestId()]
+	if !exists {
+		return nil, derrors.NewNotFoundError("request_id not found")
+	}
+	delete(m.Operation, request.GetRequestId())
+	return &grpc_common_go.Success{}, nil
 }

--- a/internal/app/provisioner/provider/azure/decommissioner.go
+++ b/internal/app/provisioner/provider/azure/decommissioner.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 Nalej
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package azure
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-08-01/containerservice"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/nalej/derrors"
+	"github.com/nalej/provisioner/internal/pkg/common"
+	"github.com/nalej/provisioner/internal/pkg/config"
+	"github.com/nalej/provisioner/internal/pkg/entities"
+	"github.com/rs/zerolog/log"
+	"time"
+)
+
+const ClusterDecommissionDeadline = 30 * time.Minute
+
+type DecommissionerOperation struct {
+	*AzureOperation
+	request entities.DecommissionRequest
+	config  *config.Config
+}
+
+func NewDecommissionerOperation(credentials *AzureCredentials, request entities.DecommissionRequest, config *config.Config) (*DecommissionerOperation, derrors.Error) {
+	azureOp, err := NewAzureOperation(credentials)
+	if err != nil {
+		return nil, err
+	}
+	return &DecommissionerOperation{
+		AzureOperation: azureOp,
+		request:        request,
+		config:         config,
+	}, nil
+}
+
+func (do *DecommissionerOperation) RequestID() string {
+	return do.request.RequestID
+}
+
+func (do *DecommissionerOperation) Metadata() entities.OperationMetadata {
+	return entities.OperationMetadata{
+		OrganizationID: do.request.OrganizationID,
+		ClusterID:      do.request.ClusterID,
+		RequestID:      do.request.RequestID,
+	}
+}
+
+func (do *DecommissionerOperation) notifyError(err derrors.Error, callback func(requestId string)) {
+	log.Error().Str("trace", err.DebugReport()).Msg("decommission operation failed")
+	do.setError(err.Error())
+	callback(do.request.RequestID)
+}
+
+func (do *DecommissionerOperation) Execute(callback func(requestID string)) {
+	log.Debug().Str("organizationID", do.request.OrganizationID).Str("clusterID", do.request.ClusterID).Msg("executing decommission operation")
+	do.started = time.Now()
+	do.SetProgress(entities.InProgress)
+
+	decommissionResponse, err := do.decommissionAksCluster()
+	if err != nil {
+		do.notifyError(err, callback)
+		return
+	}
+	log.Debug().Interface("response", *decommissionResponse).Msg("cluster has been decommissioned")
+
+	do.elapsedTime = time.Now().Sub(do.started).Nanoseconds()
+	do.SetProgress(entities.Finished)
+	callback(do.request.RequestID)
+}
+
+func (do *DecommissionerOperation) Cancel() derrors.Error {
+	panic("implement me") // TODO implement DecommissionerOperation.Cancel()
+}
+
+func (do *DecommissionerOperation) Result() entities.OperationResult {
+	elapsed := do.elapsedTime
+	if do.elapsedTime == 0 && do.taskProgress == entities.InProgress {
+		// If the operation is in progress, retrieve the ongoing time.
+		elapsed = time.Now().Sub(do.started).Nanoseconds()
+	}
+
+	return entities.OperationResult{
+		RequestId:   do.request.RequestID,
+		Type:        entities.Decommission,
+		Progress:    do.taskProgress,
+		ElapsedTime: elapsed,
+		ErrorMsg:    do.errorMsg,
+	}
+}
+
+// ScaleAKS triggers the scaling of an existing management cluster.
+func (do *DecommissionerOperation) decommissionAksCluster() (*autorest.Response, derrors.Error) {
+	do.AddToLog("Scaling existing cluster")
+	clusterClient := containerservice.NewManagedClustersClient(do.credentials.SubscriptionId)
+	clusterClient.Authorizer = do.managementAuthorizer
+
+	existingCluster, err := do.getClusterDetails(do.request.IsManagementCluster, do.request.AzureOptions.ResourceGroup, do.request.ClusterID)
+	if err != nil {
+		return nil, err
+	}
+	log.Debug().Interface("existingCluster", existingCluster).Msg("AKS cluster retrieved")
+
+	ctx, cancel := common.GetContext()
+	defer cancel()
+
+	resourceName := do.getResourceName(do.request.IsManagementCluster, do.request.ClusterID)
+	log.Debug().Str("resourceGroupName", do.request.AzureOptions.ResourceGroup).Str("resourceName", resourceName).Msg("Delete params")
+	deleteFuture, deleteErr := clusterClient.Delete(ctx, do.request.AzureOptions.ResourceGroup, resourceName)
+	if deleteErr != nil {
+		return nil, derrors.NewInternalError("cannot decommission AKS cluster", deleteErr).WithParams(do.request)
+	}
+
+	do.AddToLog("waiting for AKS cluster to be decommissioned")
+	futureContext, cancelFuture := context.WithTimeout(context.Background(), ClusterDecommissionDeadline)
+	defer cancelFuture()
+	waitErr := deleteFuture.WaitForCompletionRef(futureContext, clusterClient.Client)
+	if waitErr != nil {
+		return nil, derrors.AsError(waitErr, "AKS cluster decommission failed")
+	}
+	decommissionResponse, resultErr := deleteFuture.Result(clusterClient)
+	if resultErr != nil {
+		log.Error().Interface("err", resultErr).Msg("AKS decommission failed")
+		return nil, derrors.AsError(resultErr, "AKS decommission failed")
+	}
+	return &decommissionResponse, nil
+}

--- a/internal/app/provisioner/provider/azure/decommissioner.go
+++ b/internal/app/provisioner/provider/azure/decommissioner.go
@@ -135,11 +135,12 @@ func (do *DecommissionerOperation) Result() entities.OperationResult {
 	}
 
 	return entities.OperationResult{
-		RequestId:   do.request.RequestID,
-		Type:        entities.Decommission,
-		Progress:    do.taskProgress,
-		ElapsedTime: elapsed,
-		ErrorMsg:    do.errorMsg,
+		OrganizationId: do.request.OrganizationID,
+		RequestId:      do.request.RequestID,
+		Type:           entities.Decommission,
+		Progress:       do.taskProgress,
+		ElapsedTime:    elapsed,
+		ErrorMsg:       do.errorMsg,
 	}
 }
 

--- a/internal/app/provisioner/provider/azure/decommissioner.go
+++ b/internal/app/provisioner/provider/azure/decommissioner.go
@@ -73,7 +73,6 @@ func (do *DecommissionerOperation) Execute(callback func(requestID string)) {
 	do.started = time.Now()
 	do.SetProgress(entities.InProgress)
 
-	do.AddToLog("Obtaining Cluster information")
 	managedCluster, err := do.getClusterDetails(do.request.IsManagementCluster, do.request.AzureOptions.ResourceGroup, do.request.ClusterID)
 	if err != nil {
 		do.notifyError(err, callback)
@@ -90,7 +89,6 @@ func (do *DecommissionerOperation) Execute(callback func(requestID string)) {
 		return
 	}
 
-	do.AddToLog("Obtaining DNS zone information")
 	zone, err := do.getDNSZone(*dnsZoneName)
 	if err != nil {
 		do.notifyError(err, callback)
@@ -102,14 +100,12 @@ func (do *DecommissionerOperation) Execute(callback func(requestID string)) {
 		return
 	}
 
-	do.AddToLog("Deleting DNS entries")
 	err = do.deleteDNSEntries(*clusterName, *dnsZoneResourceGroupName, *dnsZoneName)
 	if err != nil {
 		do.notifyError(err, callback)
 		return
 	}
 
-	do.AddToLog("Decommissioning cluster")
 	decommissionResponse, err := do.decommissionAksCluster()
 	if err != nil {
 		do.notifyError(err, callback)
@@ -145,6 +141,7 @@ func (do *DecommissionerOperation) Result() entities.OperationResult {
 }
 
 func (do *DecommissionerOperation) deleteDNSEntries(clusterName string, resourceGroupName string, dnsZoneName string) derrors.Error {
+	do.AddToLog("Deleting DNS entries")
 	recordsetTypeA, err := do.listDnsRecords(resourceGroupName, dnsZoneName, clusterName)
 	if err != nil {
 		return err

--- a/internal/app/provisioner/provider/azure/decommissioner.go
+++ b/internal/app/provisioner/provider/azure/decommissioner.go
@@ -78,6 +78,8 @@ func (do *DecommissionerOperation) Execute(callback func(requestID string)) {
 		do.notifyError(err, callback)
 		return
 	}
+	log.Debug().Interface("existingCluster", managedCluster).Msg("AKS cluster retrieved")
+
 	dnsZoneName := managedCluster.Tags[DnsZoneTag]
 	if dnsZoneName == nil {
 		do.notifyError(derrors.NewFailedPreconditionError(fmt.Sprintf("Cluster entity does not contain needed tag [%s]", DnsZoneTag)), callback)
@@ -183,12 +185,6 @@ func (do *DecommissionerOperation) decommissionAksCluster() (*autorest.Response,
 	do.AddToLog("Decommissioning cluster")
 	clusterClient := containerservice.NewManagedClustersClient(do.credentials.SubscriptionId)
 	clusterClient.Authorizer = do.managementAuthorizer
-
-	existingCluster, err := do.getClusterDetails(do.request.IsManagementCluster, do.request.AzureOptions.ResourceGroup, do.request.ClusterID)
-	if err != nil {
-		return nil, err
-	}
-	log.Debug().Interface("existingCluster", existingCluster).Msg("AKS cluster retrieved")
 
 	ctx, cancel := common.GetContext()
 	defer cancel()

--- a/internal/app/provisioner/provider/azure/decommissioner.go
+++ b/internal/app/provisioner/provider/azure/decommissioner.go
@@ -181,9 +181,9 @@ func (do *DecommissionerOperation) deleteDNSEntries(clusterName string, resource
 	return nil
 }
 
-// ScaleAKS triggers the scaling of an existing management cluster.
+// decommissionAksCluster triggers the decommission of an existing management cluster.
 func (do *DecommissionerOperation) decommissionAksCluster() (*autorest.Response, derrors.Error) {
-	do.AddToLog("Scaling existing cluster")
+	do.AddToLog("Decommissioning cluster")
 	clusterClient := containerservice.NewManagedClustersClient(do.credentials.SubscriptionId)
 	clusterClient.Authorizer = do.managementAuthorizer
 

--- a/internal/app/provisioner/provider/azure/operation.go
+++ b/internal/app/provisioner/provider/azure/operation.go
@@ -298,6 +298,7 @@ func (ao *AzureOperation) getDNSResourceGroupName(zone *dns.Zone) (*string, derr
 }
 
 func (ao *AzureOperation) getDNSZone(zoneName string) (*dns.Zone, derrors.Error) {
+	ao.AddToLog("Obtaining DNS zone information")
 	zoneClient := dns.NewZonesClient(ao.credentials.SubscriptionId)
 	zoneClient.Authorizer = ao.managementAuthorizer
 	ctx, cancel := common.GetContext()
@@ -539,6 +540,7 @@ func (ao *AzureOperation) deleteDNSNSRecord(resourceGroupName string, recordName
 
 // GetClusterDetails retrieves the information of an existing cluster.
 func (ao *AzureOperation) getClusterDetails(isManagementCluster bool, resourceGroupName string, clusterID string) (*containerservice.ManagedCluster, derrors.Error) {
+	ao.AddToLog("Obtaining Cluster information")
 	clusterClient := containerservice.NewManagedClustersClient(ao.credentials.SubscriptionId)
 	clusterClient.Authorizer = ao.managementAuthorizer
 	resourceName := ao.getResourceName(isManagementCluster, clusterID)

--- a/internal/app/provisioner/provider/azure/provider.go
+++ b/internal/app/provisioner/provider/azure/provider.go
@@ -40,8 +40,8 @@ func (aip *AzureInfrastructureProvider) Provision(request entities.ProvisionRequ
 }
 
 // Decomission a cluster creates a InfrastructureOperation to decomission a cluster.
-func (aip *AzureInfrastructureProvider) Decommission() (entities.InfrastructureOperation, derrors.Error) {
-	panic("implement me")
+func (aip *AzureInfrastructureProvider) Decommission(request entities.DecommissionRequest) (entities.InfrastructureOperation, derrors.Error) {
+	return NewDecommissionerOperation(aip.credentials, request, aip.config)
 }
 
 // Scale a cluster creates a InfrastructureOperation to scale a cluster.

--- a/internal/app/provisioner/provider/azure/provisioner.go
+++ b/internal/app/provisioner/provider/azure/provisioner.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Nalej
+ * Copyright 2020 Nalej
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -218,8 +218,6 @@ func (po ProvisionerOperation) Result() entities.OperationResult {
 	}
 }
 
-
-
 func (po ProvisionerOperation) getLinuxProperties() *containerservice.LinuxProfile {
 	return &containerservice.LinuxProfile{
 		// AdminUsername set to the default azure value to facilitate other admin tasks.
@@ -227,7 +225,6 @@ func (po ProvisionerOperation) getLinuxProperties() *containerservice.LinuxProfi
 		SSH:           nil,
 	}
 }
-
 
 // createAKSCluster creates a new Kubernetes cluster managed by Azure
 //
@@ -242,7 +239,8 @@ func (po ProvisionerOperation) createAKSCluster() (*containerservice.ManagedClus
 	parameters, err := po.getKubernetesCreateRequest(
 		po.request.OrganizationID, po.request.ClusterID,
 		po.request.ClusterName, po.request.KubernetesVersion,
-		po.request.NumNodes, po.request.NodeType, po.request.Zone)
+		po.request.NumNodes, po.request.NodeType, po.request.Zone,
+		po.request.AzureOptions.DNSZoneName)
 	if err != nil {
 		return nil, err
 	}
@@ -427,5 +425,3 @@ func (po ProvisionerOperation) requestCertificate() derrors.Error {
 	return po.certManagerHelper.CreateCertificate(
 		po.getClusterName(po.request.ClusterName), po.request.AzureOptions.DNSZoneName)
 }
-
-

--- a/internal/app/provisioner/provider/entities/provider.go
+++ b/internal/app/provisioner/provider/entities/provider.go
@@ -29,7 +29,7 @@ type InfrastructureProvider interface {
 	// Provision a cluster creates a InfrastructureOperation to provision a new cluster.
 	Provision(request entities.ProvisionRequest) (entities.InfrastructureOperation, derrors.Error)
 	// Decommission a cluster creates a InfrastructureOperation to decomission a cluster.
-	Decommission() (entities.InfrastructureOperation, derrors.Error)
+	Decommission(request entities.DecommissionRequest) (entities.InfrastructureOperation, derrors.Error)
 	// Scale a cluster creates a InfrastructureOperation to scale a cluster.
 	Scale(request entities.ScaleRequest) (entities.InfrastructureOperation, derrors.Error)
 	// GetKubeConfig retrieves the KubeConfig file to access the management layer of Kubernetes.

--- a/internal/pkg/entities/provision.go
+++ b/internal/pkg/entities/provision.go
@@ -201,3 +201,45 @@ func ValidScaleClusterRequest(request *grpc_provisioner_go.ScaleClusterRequest) 
 	}
 	return nil
 }
+
+func ValidDecommissionClusterRequest(request *grpc_provisioner_go.DecomissionClusterRequest) derrors.Error {
+	if request.RequestId == "" {
+		return derrors.NewInvalidArgumentError("request_id must be set")
+	}
+	if !request.IsManagementCluster && request.OrganizationId == "" {
+		return derrors.NewInvalidArgumentError("organization_id must be set")
+	}
+	if !request.IsManagementCluster && request.ClusterId == "" {
+		return derrors.NewInvalidArgumentError("cluster_id must be set")
+	}
+	if request.TargetPlatform == grpc_installer_go.Platform_AZURE && request.AzureCredentials == nil {
+		return derrors.NewInvalidArgumentError("azure_credentials must be set when type is Azure")
+	}
+	if request.TargetPlatform == grpc_installer_go.Platform_AZURE && request.AzureOptions == nil {
+		return derrors.NewInvalidArgumentError("azure_options must be set when type is Azure")
+	}
+	return nil
+}
+
+type DecommissionRequest struct {
+	// RequestID with the request identifier.
+	RequestID string
+	// OrganizationId with the organization identifier.
+	OrganizationID string
+	// ClusterId with the cluster identifier.
+	ClusterID string
+	// IsManagementCluster to determine if the scaling is for a management or application cluster.
+	IsManagementCluster bool
+	// AzureOptions with the provisioning specific options.
+	AzureOptions *AzureOptions
+}
+
+func NewDecommissionRequest(request *grpc_provisioner_go.DecomissionClusterRequest) DecommissionRequest {
+	return DecommissionRequest{
+		RequestID:           request.GetRequestId(),
+		OrganizationID:      request.GetOrganizationId(),
+		ClusterID:           request.GetClusterId(),
+		IsManagementCluster: request.GetIsManagementCluster(),
+		AzureOptions:        NewAzureOptions(request.GetAzureOptions()),
+	}
+}


### PR DESCRIPTION
#### What does this PR do?
Implement the decommission routine to allow the provisioner to release the resources of a cluster.

#### What is missing?
Implement cancel operations.

#### How should this be manually tested?
```shell script
./provisioner-cli decommission --azureCredentialsPath ~/.azure/mgarcia_provisioner.json --name {{cluster-name}} --platform AZURE --resourceGroup dev
```

#### What are the relevant tickets?
- [NP-2402](https://nalej.atlassian.net/browse/NP-2402)